### PR TITLE
create index in background

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ class Leader extends EventEmitter {
         if (err.message !== 'ns not found') throw err;
       })
       .then(() => this.db.createCollection(this.key))
-      .then((collection) => collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: this.options.ttl / 1000 }));
+      .then((collection) => collection.createIndex({ createdAt: 1 }, { expireAfterSeconds: this.options.ttl / 1000, background: true }));
   }
 
   isLeader() {


### PR DESCRIPTION
Create index in background so we don't get strange error like:
UnhandledPromiseRejectionWarning: MongoError: cannot perform operation: a background operation is currently running for collection Barabas.leader-0734d7e2a8438670dffb9ed87d2504f5456fac3f
when multiple nodes tries to join at the same time.