### PR TITLE
make transactionLifetimeLimitSeconds configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,11 @@ class Leader extends EventEmitter {
   initDatabase() {
     return this.db.command({ ping: 1 })
       .then(() => {
-        this.db.executeDbAdminCommand({ setParameter: 1, ttlMonitorSleepSecs: 1 });
-        this.db.executeDbAdminCommand({ setParameter: 1, transactionLifetimeLimitSeconds: this.options.transactionLifetimeLimitSeconds });
+        this.db.executeDbAdminCommand({ 
+          setParameter: 1, 
+          ttlMonitorSleepSecs: 1, 
+          transactionLifetimeLimitSeconds: this.options.transactionLifetimeLimitSeconds 
+        });
       })
       .then(() => this.db.listCollections({ name: this.key }))
       .catch((err) => {


### PR DESCRIPTION
Adding configurable transaction timeout feature, when inserting large documents into mongo, the transaction can timeout.
